### PR TITLE
feat(ui): 사이드바 수동 접기 상태 유지 기능 추가

### DIFF
--- a/src/app/(main)/_components/layout/header.tsx
+++ b/src/app/(main)/_components/layout/header.tsx
@@ -30,12 +30,11 @@ import {
   useSignout,
 } from '@/hooks/api';
 import { useStore } from '@/store/store';
-import { selectIsSidebarOpen, selectToggleSidebar } from '@/store/ui';
+import { selectIsSidebarOpen, selectToggleMaualSidebar } from '@/store/ui';
 
 export function Header() {
   const isSidebarOpen = useStore(selectIsSidebarOpen);
-  const toggleSidebar = useStore(selectToggleSidebar);
-  console.log('toggleSidebar', toggleSidebar);
+  const toggleMaualSidebar = useStore(selectToggleMaualSidebar);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const { isLoading, data } = useMe();
   const { mutateAsync: signout } = useSignout();
@@ -50,13 +49,13 @@ export function Header() {
     <header className="h-14 border-b border-border bg-card">
       <div className="h-full flex items-center px-4 lg:px-6">
         <button
-          onClick={() => toggleSidebar()}
+          onClick={() => toggleMaualSidebar()}
           className="lg:hidden mr-4 p-2 hover:bg-accent/50 rounded-md"
         >
           <Menu className="h-5 w-5" />
         </button>
         <button
-          onClick={() => toggleSidebar()}
+          onClick={() => toggleMaualSidebar()}
           className="hidden lg:block mr-4 p-2 hover:bg-accent/50 rounded-md"
         >
           {isSidebarOpen ? (

--- a/src/app/(main)/_components/layout/sidebar.tsx
+++ b/src/app/(main)/_components/layout/sidebar.tsx
@@ -7,13 +7,14 @@ import {
 import {
   UserAvatar,
 } from '@/components/user-avatar';
-import { selectIsSidebarOpen, selectToggleSidebar } from '@/store/ui';
+import { selectIsMaualSidebarOpen, selectIsSidebarOpen, selectToggleSidebar } from '@/store/ui';
 import { useStore } from '@/store/store';
 import { useCallback, useEffect } from 'react';
 import { BREAKPOINTS } from '@/constants';
 import { useWindowSize } from '@/hooks/ui';
 export function Sidebar() {
   const isSidebarOpen = useStore(selectIsSidebarOpen);
+  const isMaualSidebarOpen = useStore(selectIsMaualSidebarOpen);
   const toggleSidebar = useStore(selectToggleSidebar);
   
   const { width } = useWindowSize();
@@ -23,8 +24,10 @@ export function Sidebar() {
   useEffect(() => {
     if (width) {
       const isTabletMin = width <= BREAKPOINTS.MD.max;
-      // 큰 화면에서는 항상 열려있고, 작은 화면에서는 닫혀있도록 설정
-      toggleSidebar(!isTabletMin);
+      // 수동으로 접었을 때만 자동으로 접히고 펼쳐지도록 수정
+      if(!isMaualSidebarOpen) {  
+        toggleSidebar(!isTabletMin);
+      }
     }
   }, [width]); // toggleSidebar 의존성 제거
 

--- a/src/store/ui/slice.ts
+++ b/src/store/ui/slice.ts
@@ -3,22 +3,27 @@ import { StateCreator } from 'zustand';
 // State
 interface UISliceState {
   isSidebarOpen: boolean;
+  isMaualSidebarOpen: boolean;
 }
 
 // Actions
 interface UISliceActions {
   toggleSidebar: (value?: boolean) => void;
+  toggleMaualSidebar: (value?: boolean) => void;
 }
 
 // Selectors
 export const selectIsSidebarOpen = (state: UISliceState) => state.isSidebarOpen;
 export const selectToggleSidebar = (state: UISliceActions) => state.toggleSidebar;
+export const selectIsMaualSidebarOpen = (state: UISliceState) => state.isMaualSidebarOpen;
+export const selectToggleMaualSidebar = (state: UISliceActions) => state.toggleMaualSidebar;
 // Slice Type
 export type UISlice = UISliceState & UISliceActions;
 
 // Initial State
 const initialState: UISliceState = {
   isSidebarOpen: true,
+  isMaualSidebarOpen: true,
 };
 
 // Slice Creator
@@ -26,5 +31,9 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set) => ({
   ...initialState,
   toggleSidebar: (value) => set((state) => ({
       isSidebarOpen: typeof value === 'boolean' ? value : !state.isSidebarOpen 
+  })),
+  toggleMaualSidebar: (value) => set((state) => ({
+    isSidebarOpen: typeof value === 'boolean' ? value : !state.isSidebarOpen,
+    isMaualSidebarOpen: typeof value === 'boolean' ? value : !state.isMaualSidebarOpen
   })),
 }); 


### PR DESCRIPTION
## 기능 추가: 사이드바 수동 접기 기능

이 PR은 사이드바의 동작을 개선하여 사용자가 수동으로 접은 상태를 유지하도록 하는 기능을 추가합니다.

### 변경 사항
1. `UISlice`에 새로운 상태 `isMaualSidebarOpen` 추가
2. 새로운 액션 `toggleMaualSidebar` 구현
3. 헤더에 있는 토글 버튼은 `toggleMaualSidebar`를 사용하도록 수정
4. 사이드바 컴포넌트는 `isMaualSidebarOpen` 상태를 확인하여 화면 크기 변경 시 자동으로 사이드바를 접고 펼치는 기능에 조건 추가

### 장점
- 사용자가 수동으로 사이드바를 접었을 때, 브라우저 창 크기를 변경해도 사이드바가 자동으로 열리지 않음
- 사용자의 의도를 존중하여 더 나은 UX 제공
- 작업 공간을 더 효율적으로 사용할 수 있게 됨

### 테스트 방법
1. 사이드바를 수동으로 접고 창 크기를 변경해 보세요 (접힌 상태 유지)
2. 사이드바를 수동으로 펼치고 창 크기를 변경해 보세요 (펼쳐진 상태 유지)
3. 새로고침 후 기본 동작 확인 (창 크기에 따라 자동으로 펼쳐짐)