### PR TITLE
feat(ui): 사이드바 토글 기능 구현

### DIFF
--- a/src/app/(main)/_components/layout/header.tsx
+++ b/src/app/(main)/_components/layout/header.tsx
@@ -30,11 +30,12 @@ import {
   useSignout,
 } from '@/hooks/api';
 import { useStore } from '@/store/store';
-import { selectIsSidebarOpen, selectToggleMaualSidebar } from '@/store/ui';
+import { selectIsSidebarOpen, selectToggleMaualSidebar, selectToggleSidebar } from '@/store/ui';
 
 export function Header() {
   const isSidebarOpen = useStore(selectIsSidebarOpen);
   const toggleMaualSidebar = useStore(selectToggleMaualSidebar);
+  const toggleSidebar = useStore(selectToggleSidebar);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const { isLoading, data } = useMe();
   const { mutateAsync: signout } = useSignout();
@@ -49,7 +50,7 @@ export function Header() {
     <header className="h-14 border-b border-border bg-card">
       <div className="h-full flex items-center px-4 lg:px-6">
         <button
-          onClick={() => toggleMaualSidebar()}
+          onClick={() => toggleSidebar()}
           className="lg:hidden mr-4 p-2 hover:bg-accent/50 rounded-md"
         >
           <Menu className="h-5 w-5" />

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,14 +6,11 @@ import { UISlice, createUISlice } from './ui';
 
 type Store = UISlice;
 
-type PersistedState = Pick<Store, 'isSidebarOpen'>;
+type PersistedState = Pick<Store, 'isMaualSidebarOpen'>;
 
 const persistOptions: PersistOptions<Store, PersistedState> = {
   name: 'yaong-storage',
   storage: createJSONStorage(() => localStorage),
-  partialize: (state) => ({
-    isSidebarOpen: state.isSidebarOpen,
-  }),
 };
 
 export const useStore = create<Store>()(

--- a/src/store/ui/slice.ts
+++ b/src/store/ui/slice.ts
@@ -22,7 +22,7 @@ export type UISlice = UISliceState & UISliceActions;
 
 // Initial State
 const initialState: UISliceState = {
-  isSidebarOpen: true,
+  isSidebarOpen: false,
   isMaualSidebarOpen: true,
 };
 


### PR DESCRIPTION
## 변경사항
- 데스크톱/모바일 사이드바 토글 상태 관리 추가
- 사이드바 상태 영구 저장 기능 구현
- 헤더 컴포넌트에 사이드바 토글 버튼 추가

## 테스트 방법
1. 데스크톱 화면에서 헤더의 사이드바 토글 버튼이 정상 작동하는지 확인
2. 모바일 화면에서 사이드바 토글 버튼이 정상 작동하는지 확인
3. 페이지 새로고침 후에도 사이드바 상태가 유지되는지 확인